### PR TITLE
Set name param for Codecov reports

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
           file: ./coverage.xml # optional
+          name: ${{ matrix.os }}, python ${{ matrix.python-version }}
   build-and-publish:
     needs: build-and-test
     name: Build and publish Python 🐍 distributions 📦 to PyPI


### PR DESCRIPTION
Show builds as eg. "ubuntu-latest, python 3.8" under build information in Codecov.